### PR TITLE
Fix error on nightly rustc

### DIFF
--- a/src/customers/mod.rs
+++ b/src/customers/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod handler;
 pub mod repository;
-use mongodb::bson;
+use mongodb as bson;
 use serde::{Serialize, Deserialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/customers/repository.rs
+++ b/src/customers/repository.rs
@@ -3,6 +3,7 @@ use crate::customers::{Customer, InsertableCustomer};
 use crate::mongo_connection::Pool;
 use r2d2_mongodb::mongodb::db::ThreadedDatabase;
 use mongodb::{bson, coll::results::DeleteResult, doc, error::Error, oid::ObjectId}; 
+use mongodb as bson;
 
 const COLLECTION: &str = "customers";
 


### PR DESCRIPTION
Looks like this crate relies on a deprecated functionality in `rustc` - `use mongodb::bson` imports a private `extern crate` item from a different crate.
This was found during ecosystem testing in https://github.com/rust-lang/rust/pull/80763.
This PR fixes the issue.